### PR TITLE
Support faster processors and more accurate ADC (e.g. ESP32)

### DIFF
--- a/ACS712.cpp
+++ b/ACS712.cpp
@@ -10,6 +10,7 @@
 // 0.1.1    2020-03-18 first release version
 // 0.1.2	2020-03-21 automatic formfactor test
 // 0.1.3    2020-05-27 fix library.json
+// 0.1.4    2020-08-02 Allow for faster processors
 //
 
 #include "ACS712.h"
@@ -22,14 +23,15 @@ ACS712::ACS712(uint8_t analogPin, float volts, uint16_t maxADC, uint8_t mVperA)
     _mVperAmpere = mVperA;
     _formFactor = 0.70710678119;  // 0.5 * sqrt(2);  TODO: should be smaller in practice 0.5 ?
     _midPoint = maxADC / 2;
+    _noise = 0.021 * (maxADC / volts); // Noise is 21mV according to datasheet
 }
 
 int ACS712::mA_AC(uint8_t freq)
 {
     uint32_t start = micros();
     uint16_t period = ((freq == 60) ? 16670 : 20000);
-    uint8_t samples = 0;
-    uint8_t zeros = 0;
+    uint16_t samples = 0;
+    uint16_t zeros = 0;
     int _min, _max;
     _min = _max = analogRead(_pin);
     while (micros() - start < period)  // UNO ~180 samples...
@@ -38,20 +40,20 @@ int ACS712::mA_AC(uint8_t freq)
         int val = analogRead(_pin);
         if (val < _min) _min = val;
         if (val > _max) _max = val;
-        if (abs(val - _midPoint) < 4) zeros++;   // Noise max 4 during test
+        if (abs(val - _midPoint) < _noise) zeros++;   // Noise max 4 during test
     }
     int p2p = (_max - _min);
 
-    // automatic determine _formFactor / crest factor   
-    float D = 0;	
+    // automatic determine _formFactor / crest factor
+    float D = 0;
     float FF = 0;
-    if (zeros > 5)                          // MAGIC NUMBER 5 ~2.5% of samples = zero
+    if (zeros > samples * 0.025)
     {
       D = 1.0 - (1.0 * zeros) / samples;    // % SAMPLES NONE ZERO
       FF = sqrt(D) * 0.5 * sqrt(2);         // ASSUME NON ZERO PART ~ SINUS
-	}
-	else  // # zeros is small => D --> 1 --> sqrt(D) --> 1
-	{
+    }
+    else  // # zeros is small => D --> 1 --> sqrt(D) --> 1
+    {
       FF = 0.5 * sqrt(2);
     }
     _formFactor = FF;

--- a/ACS712.h
+++ b/ACS712.h
@@ -46,6 +46,10 @@ class ACS712
     inline void     setFormFactor(float ff) { _formFactor = ff; };
     inline float    getFormFactor() { return _formFactor; };
 
+    // noise
+    inline void     setNoise(uint8_t noise) { _noise = noise; };
+    inline uint8_t  getNoise() { return _noise; };
+
     // AC and DC
     inline void     setmVperAmp(uint8_t mva) { _mVperAmpere = mva; };
     inline uint8_t  getmVperAmp() { return _mVperAmpere; };
@@ -56,6 +60,7 @@ class ACS712
     float     _formFactor;    // P2P -> RMS
     uint8_t   _mVperAmpere;
     uint16_t  _midPoint;
+    uint8_t   _noise;
 };
 
 // END OF FILE


### PR DESCRIPTION
I've made a couple of changes. Firstly, I needed to allow for 16 bit integers for the zero and sample counts since the ESP32 samples much faster. Secondly, I calculated noise (and allowed it to be modified) based on the datasheet and the max range of the ADC rather than hardcoding 4 (which was much to low for my ESP32)