### PR TITLE
Add autoConfigure

### DIFF
--- a/ACS712.cpp
+++ b/ACS712.cpp
@@ -71,13 +71,16 @@ int ACS712::mA_DC()
     return 1000.0 * steps * _mVpstep / _mVperAmpere;
 }
 
-// configure by sampling for a period of time, assuming that no current is flowing
+// configure by sampling for a period of time, assuming that no DC current is flowing
 void ACS712::autoMidPoint(uint16_t timeMillis)
 {
   uint32_t startTime = millis();
   uint32_t total = 0;
-  uint32_t samples = 1;
-  while (millis() - startTime < timeMillis) {
+  uint32_t samples = 0;
+  // Ensure at least 2 cycles of AC (we're going to ignore 60hz vs. 50hz and just use the longer time period)
+  timeMillis = constrain(timeMillis, 40, 0xffff);
+  // Stop if we're in danger of overflow
+  while ((millis() - startTime < timeMillis) && (total < 0xFFFF0000)) {
     uint16_t reading = analogRead(_pin);
     total += reading;
     samples ++;

--- a/ACS712.h
+++ b/ACS712.h
@@ -41,9 +41,8 @@ class ACS712
     inline uint16_t getMidPoint() { return _midPoint; };
     inline void     incMidPoint() { _midPoint++; };
     inline void     decMidPoint() { _midPoint--; };
-    // Auto midPoint, assuming zero DC current or AC current
-    // Take readings for the allotted time, infer midpoint
-    void autoMidPoint(uint16_t timeMillis = 40);
+    // Auto midPoint, assuming zero DC current or any AC current
+    void autoMidPoint(uint8_t freq = 50);
 
     // also known as crest factor;  affects AC only
     inline void     setFormFactor(float ff) { _formFactor = ff; };

--- a/ACS712.h
+++ b/ACS712.h
@@ -41,9 +41,9 @@ class ACS712
     inline uint16_t getMidPoint() { return _midPoint; };
     inline void     incMidPoint() { _midPoint++; };
     inline void     decMidPoint() { _midPoint--; };
-    // Auto midPoint, assuming zero current
+    // Auto midPoint, assuming zero DC current or AC current
     // Take readings for the allotted time, infer midpoint
-    void autoMidPoint(uint16_t timeMillis = 200);
+    void autoMidPoint(uint16_t timeMillis = 40);
 
     // also known as crest factor;  affects AC only
     inline void     setFormFactor(float ff) { _formFactor = ff; };

--- a/ACS712.h
+++ b/ACS712.h
@@ -36,6 +36,10 @@ class ACS712
     // blocks < 1 ms
     int        mA_DC();
 
+    // Auto configure, assuming zero current
+    // Take readings for the allotted time, infer midpoint and noise
+    void autoConfigure(uint16_t timeMillis = 200, float extraNoisemV=5);
+
     // midpoint ADC for DC only
     inline void setMidPoint(uint16_t mp) { _midPoint = mp; };
     inline uint16_t getMidPoint() { return _midPoint; };

--- a/ACS712.h
+++ b/ACS712.h
@@ -2,8 +2,8 @@
 //
 //    FILE: ACS712.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.3
-//    DATE: 2020-03-17
+// VERSION: 0.2.0
+//    DATE: 2020-08-02
 // PURPOSE: ACS712 library - current measurement
 //
 // Tested with a RobotDyn ACS712 20A breakout + UNO.
@@ -36,23 +36,22 @@ class ACS712
     // blocks < 1 ms
     int        mA_DC();
 
-    // Auto configure, assuming zero current
-    // Take readings for the allotted time, infer midpoint and noise
-    void autoConfigure(uint16_t timeMillis = 200, float extraNoisemV=5);
-
     // midpoint ADC for DC only
     inline void setMidPoint(uint16_t mp) { _midPoint = mp; };
     inline uint16_t getMidPoint() { return _midPoint; };
     inline void     incMidPoint() { _midPoint++; };
     inline void     decMidPoint() { _midPoint--; };
+    // Auto midPoint, assuming zero current
+    // Take readings for the allotted time, infer midpoint
+    void autoMidPoint(uint16_t timeMillis = 200);
 
     // also known as crest factor;  affects AC only
     inline void     setFormFactor(float ff) { _formFactor = ff; };
     inline float    getFormFactor() { return _formFactor; };
 
     // noise
-    inline void     setNoise(uint8_t noise) { _noise = noise; };
-    inline uint8_t  getNoise() { return _noise; };
+    inline void     setNoisemV(uint8_t noisemV) { _noisemV = noisemV; };
+    inline uint8_t  getNoisemV() { return _noisemV; };
 
     // AC and DC
     inline void     setmVperAmp(uint8_t mva) { _mVperAmpere = mva; };
@@ -64,7 +63,7 @@ class ACS712
     float     _formFactor;    // P2P -> RMS
     uint8_t   _mVperAmpere;
     uint16_t  _midPoint;
-    uint8_t   _noise;
+    uint8_t   _noisemV;
 };
 
 // END OF FILE

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Current Sensor - 5A, 20A, 30A
 
 ## Description
 
-The ACS712 is a chip to measure current, both AC or DC. The chip has an 
-analog output that provides a voltage that is lineair with the current. 
+The ACS712 is a chip to measure current, both AC or DC. The chip has an
+analog output that provides a voltage that is lineair with the current.
 The ACS712 library supports only a built in ADC by means of analogRead().
 There are 2 core functions:
 
 * **int mA_DC()**
 * **int mA_AC()**
 
-To measure DC current a single analogRead() with some conversion math is sufficient to get 
+To measure DC current a single analogRead() with some conversion math is sufficient to get
 a value. To stabilize the signal analogRead() is called twice.
 
-To measure AC current **a blocking loop for 20 millis** is run to determine the 
-peak to peak value which is converted to the RMS value. To convert the peak2peak 
-value to RMS one need the so called crest or form factor. This factor depends heavily 
+To measure AC current **a blocking loop for 20 millis** is run to determine the
+peak to peak value which is converted to the RMS value. To convert the peak2peak
+value to RMS one need the so called crest or form factor. This factor depends heavily
 on the signal form. For a perfect sinus the value is sqrt(2)/2.
 
 ## Test
@@ -26,16 +26,18 @@ The library is tested with the RobotDyn ACS712 20A breakout and an Arduino UNO.
 
 ## Operation
 
-With the constructor the parameters **volts** and **maxADC (steps)** of the ADC are set 
-together with the **milliVolt per Ampere** value. The last parameter can be adjusted 
-afterwards, e.g. to callibrate this value runtime. Note this parameter affects both 
+With the constructor the parameters **volts** and **maxADC (steps)** of the ADC are set
+together with the **milliVolt per Ampere** value. The last parameter can be adjusted
+afterwards, e.g. to callibrate this value runtime. Note this parameter affects both
 AC and DC measurements.
 
-To callibrate the zero level for DC measurements, 4 functions are available to 
+To callibrate the zero level for DC measurements, 5 functions are available to
 adjust the midPoint.
 
-To callibrate the RMS value for AC measurements, 2 functions are available to 
+To callibrate the RMS value for AC measurements, 2 functions are available to
 get and set the formFactor.
 
-The examples show the basic working of the functions.
+To callibrate the noise level (used for AC measurements), 2 functions are available to
+get and set the noise in mV.
 
+The examples show the basic working of the functions.

--- a/examples/ACS712_20_AC/ACS712_20_AC.ino
+++ b/examples/ACS712_20_AC/ACS712_20_AC.ino
@@ -15,17 +15,28 @@
 // ACS712 30A uses  66 mV per A
 
 ACS712  ACS(A0, 5.0, 1023, 100);
+// ESP 32 example (requires resistors to step down the logic voltage)
+//ACS712  ACS(25, 5.0, 4095, 185);
 
 void setup()
 {
   Serial.begin(115200);
   Serial.println(__FILE__);
+
+  ACS.autoMidPoint();
+  Serial.print("MidPoint: ");
+  Serial.print(ACS.getMidPoint());
+  Serial.print(". Noise mV: ");
+  Serial.println(ACS.getNoisemV());
 }
 
 void loop()
 {
   int mA = ACS.mA_AC();
-  Serial.println(mA);
+  Serial.print("mA: ");
+  Serial.print(mA);
+  Serial.print(". Form factor: ");
+  Serial.println(ACS.getFormFactor());
 }
 
 // END OF FILE

--- a/examples/ACS712_20_AC_DEMO/ACS712_20_AC_DEMO.ino
+++ b/examples/ACS712_20_AC_DEMO/ACS712_20_AC_DEMO.ino
@@ -15,11 +15,14 @@
 // ACS712 30A uses  66 mV per A
 
 ACS712  ACS(A0, 5.0, 1023, 100);
+// ESP 32 example (requires resistors to step down the logic voltage)
+//ACS712  ACS(25, 5.0, 4095, 185);
 
 void setup()
 {
   Serial.begin(115200);
   Serial.println(__FILE__);
+  ACS.autoMidPoint();
 }
 
 void loop()

--- a/examples/ACS712_20_DC/ACS712_20_DC.ino
+++ b/examples/ACS712_20_DC/ACS712_20_DC.ino
@@ -15,11 +15,14 @@
 // ACS712 30A uses  66 mV per A
 
 ACS712  ACS(A0, 5.0, 1023, 100);
+// ESP 32 example (requires resistors to step down the logic voltage)
+//ACS712  ACS(25, 5.0, 4095, 185);
 
 void setup()
 {
   Serial.begin(115200);
   Serial.println(__FILE__);
+  ACS.autoMidPoint();
 }
 
 void loop()

--- a/examples/ACS712_20_DC_DEMO/ACS712_20_DC_DEMO.ino
+++ b/examples/ACS712_20_DC_DEMO/ACS712_20_DC_DEMO.ino
@@ -15,11 +15,14 @@
 // ACS712 30A uses  66 mV per A
 
 ACS712  ACS(A0, 5.0, 1023, 100);
+// ESP 32 example (requires resistors to step down the logic voltage)
+//ACS712  ACS(25, 5.0, 4095, 185);
 
 void setup()
 {
   Serial.begin(115200);
   Serial.println(__FILE__);
+  ACS.autoMidPoint();
 }
 
 void loop()

--- a/library.json
+++ b/library.json
@@ -8,14 +8,20 @@
       "name": "Rob Tillaart",
       "email": "Rob.Tillaart@gmail.com",
       "maintainer": true
+    },
+    {
+      "name": "Pete Thompson",
+      "email": "pete.thompson@yahoo.com",
+      "maintainer": false
     }
+
   ],
   "repository":
   {
     "type": "git",
     "url": "https://github.com/RobTillaart/ACS712"
   },
-  "version":"0.1.3",
+  "version":"0.2.0",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=ACS712
-version=0.1.3
-author=Rob Tillaart <rob.tillaart@gmail.com>
+version=0.2.0
+author=Rob Tillaart <rob.tillaart@gmail.com>, Pete Thompson <pete.thompson@yahoo.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
-sentence=ACS712 library for Arduino. 
+sentence=ACS712 library for Arduino.
 paragraph=Current measurement, tested with RobotDyn ACDC 20A Module.
 category=Signal Input/Output
 url=https://github.com/RobTillaart/ACS712


### PR DESCRIPTION
I've added a method to allow quick configuration of the midpoint and noise level based on taking readings. I'm finding that in my circuit the 5V line isn't always 5v (it's 5.1 when connected to my Mac USB), hence the midpoint isn't where it's expected and the easiest way for me to configure is to capture actual ADC values with no current running.