### PR TITLE
Use raw values

### DIFF
--- a/ACS712.cpp
+++ b/ACS712.cpp
@@ -442,6 +442,16 @@ void ACS712::setADC(uint16_t (* f)(uint8_t), float volts, uint16_t maxADC)
   _midPoint    = maxADC / 2;
 }
 
+void ACS712::setADCRaw(uint16_t f, float volts, uint16_t maxADC)
+{
+  _readADCRaw = f;
+
+  _maxADC      = maxADC;
+  _mVperStep   = 1000.0 * volts / maxADC;  //  1x 1000 for V -> mV
+  _mAPerStep   = 1000.0 * _mVperStep / _mVperAmpere;
+  _midPoint    = maxADC / 2;
+}
+
 
 //////////////////////////////////////////////////////////////////////
 //
@@ -451,6 +461,7 @@ uint16_t ACS712::_analogRead(uint8_t pin)
 {
   //  if external ADC is defined use it.
   if (_readADC != NULL) return _readADC(pin);
+  if (_raw) return _readADCRaw;
   return analogRead(pin);
 }
 

--- a/ACS712.h
+++ b/ACS712.h
@@ -121,6 +121,8 @@ class ACS712
     //  function returning 16 bit max, with pin or channel as parameter
     void setADC(uint16_t (*)(uint8_t), float volts, uint16_t maxADC);
 
+    // Use raw value as an option
+    void setADCRaw(uint16_t f, float volts, uint16_t maxADC);
 
   private:
     uint8_t   _pin;

--- a/ACS712.h
+++ b/ACS712.h
@@ -138,7 +138,10 @@ class ACS712
     //  supports up to 16 bits ADC.
     uint16_t (* _readADC)(uint8_t);
     uint16_t _analogRead(uint8_t pin);
-    
+
+    // Added for raw values
+    bool _raw;
+    uint16_t _readADCRaw;
 };
 
 

--- a/examples/ACS712_ESP32_external_ADC_Raw_Async/.arduino-ci.yml
+++ b/examples/ACS712_ESP32_external_ADC_Raw_Async/.arduino-ci.yml
@@ -1,0 +1,30 @@
+platforms:
+  rpipico:
+    board: rp2040:rp2040:rpipico
+    package: rp2040:rp2040
+    gcc:
+      features:
+      defines:
+        - ARDUINO_ARCH_RP2040
+      warnings:
+      flags:
+
+packages:
+  rp2040:rp2040:
+    url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+
+compile:
+  # Choosing to run compilation tests on 2 different Arduino platforms
+  platforms:
+    # - uno
+    # - due
+    # - zero
+    # - leonardo
+    # - m4
+    - esp32
+    # - esp8266
+    # - mega2560
+    # - rpipico
+  libraries:
+    - ADS1x15
+

--- a/examples/ACS712_ESP32_external_ADC_Raw_Async/ACS712_ESP32_external_ADC_Raw_Async.ino
+++ b/examples/ACS712_ESP32_external_ADC_Raw_Async/ACS712_ESP32_external_ADC_Raw_Async.ino
@@ -1,0 +1,76 @@
+//    FILE: ACS712_ESP32_external_ADC_Raw_Async.ino
+//  AUTHOR: Stian Blåsberg
+// PURPOSE: demo to measure mA DC with external ADC using raw values - asynchronous
+//     URL: https://github.com/RobTillaart/ACS712
+
+#include "Arduino.h"
+#include "ACS712.h"
+#include "ADS1X15.h"
+
+
+//  I2C config
+#define ADS1015_ADDRESS         0x48
+#define ADS1015_SCL             22   //  default SCL ESP32
+#define ADS1015_SDA             21   //  default SDA ESP32
+
+//  ADS1x15 config
+#define SENSOR_ACS712_ADSPIN    1
+
+uint16_t rawAdsValue;
+
+
+//  explicit parameters for demo
+ADS1015 ads1015(ADS1015_ADDRESS, &Wire);  //  ADS1015 == 12 bit
+
+
+//  SENSOR_ACS712_ADSPIN sets pin 1 of the ADS1015, 3.3 volt, 4095 = 12 bit, 100 = mVperAmpere
+ACS712 ACS(SENSOR_ACS712_ADSPIN, 3.3, 4095, 100);
+
+///////////////////////////////////////////////////////////////
+
+void setup() 
+{
+  Serial.begin(115200);
+  while (!Serial);
+  Serial.println(__FILE__);
+  Serial.print("ACS712_LIB_VERSION: ");
+  Serial.println(ACS712_LIB_VERSION);
+  Serial.print("ADS1X15_LIB_VERSION: ");
+  Serial.println(ADS1X15_LIB_VERSION);
+  Serial.println();
+
+
+  //  ESP32 set wire pins explicitly
+  Wire.begin(ADS1015_SDA, ADS1015_SCL);
+  Wire.setClock(400000);
+
+
+  //  initialize ADS1015, if fail => report
+  if (ads1015.begin() == false)
+  {
+    Serial.println("ADS1x15 not found. Check wires and pins. Reboot.");
+    while(1);
+  }
+
+  //  set up the external ADC for the ACS712
+  ACS.setADCRaw(rawAdsValue, 3.3, 4095);
+  ads1015.requestADC(0);
+}
+
+
+void loop()
+{
+  if (ads1015.isBusy() == false)
+  {
+    int16_t val_0 = ads1015.getValue();
+    //  request a new one
+    ads1015.requestADC(0);
+    int mA = ACS.mA_DC();
+    Serial.println(mA);
+  }
+  //  simulate other tasks...
+  delay(1000);
+}
+
+
+//  -- END OF FILE --


### PR DESCRIPTION
May not be of interest, but the orginal setADC did not work good enough for me. Added setADCRaw which allows to use raw values, and included an async example of doing this like in [ADS1X15](https://github.com/RobTillaart/ADS1X15/tree/master).